### PR TITLE
Consider changing Composer package type to "phpcodesniffer-standard"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "mygento/coding-standard",
   "description": "A set of PHP rules and sniffs",
+  "type": "phpcodesniffer-standard",
   "homepage": "https://github.com/mygento/coding-standard",
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
This PR suggests changing the Composer package type to enable automatic standard registration via the [PHPCSStandards Composer installer plugin][composer-installer].

## Problem/Motivation

Composer allows declaring [a package's type][composer-package-type]. When no type is declared, the default is "library".

There is a [Composer plugin][composer-plugin] that can install custom PHP_CodeSniffer standards: https://github.com/PHPCSStandards/composer-installer

This plugin is part of the [PHPCSStandards][php-cs-standards] organisation, which is the new official home of [PHP_CodeSniffer][php-codesniffer].

For this installer to work, the package type needs to be set to `phpcodesniffer-standard`.

There are already [over 470 packages][phpcodesniffer-packages] that use this type. As a side benefit, using this type will allow end-users to more easily find other external PHP_CodeSniffer standards that may be interesting to them when searching on Packagist.

## Proposed changes

Add `"type": "phpcodesniffer-standard"` to `composer.json`.

This will in _no way_ change the existing behavior of this package for users that do not include the Composer plugin mentioned above in their projects' `composer.json`.

[composer-installer]: https://github.com/PHPCSStandards/composer-installer
[composer-package-type]: https://getcomposer.org/doc/04-schema.md#type
[composer-plugin]: https://getcomposer.org/doc/articles/plugins.md
[php-codesniffer]: https://github.com/PHPCSStandards/PHP_CodeSniffer
[php-cs-standards]: https://github.com/PHPCSStandards/
[phpcodesniffer-packages]: https://packagist.org/?type=phpcodesniffer-standard